### PR TITLE
Fix CI failures from deprecated actions and broken textlint target

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,14 +11,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Create Cache Directory
         run: mkdir -p ~/cache
 
       - name: Cache Directory
         id: cache
-        uses: actions/cache@v4
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/cache
           key: cache-${{ runner.os }}
@@ -37,7 +37,7 @@ jobs:
         run: make build
 
       - name: Upload PDF
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: artifacts
           path: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
 
       - name: Cache Directory
         id: cache
-        uses: actions/cache/@v3
+        uses: actions/cache@v4
         with:
           path: ~/cache
           key: cache-${{ runner.os }}
@@ -37,7 +37,7 @@ jobs:
         run: make build
 
       - name: Upload PDF
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: artifacts
           path: |

--- a/.github/workflows/dry-run.yml
+++ b/.github/workflows/dry-run.yml
@@ -11,14 +11,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Create Cache Directory
         run: mkdir -p ~/cache
 
       - name: Cache Directory
         id: cache
-        uses: actions/cache@v4
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/cache
           key: cache-${{ runner.os }}

--- a/.github/workflows/dry-run.yml
+++ b/.github/workflows/dry-run.yml
@@ -18,7 +18,7 @@ jobs:
 
       - name: Cache Directory
         id: cache
-        uses: actions/cache/@v3
+        uses: actions/cache@v4
         with:
           path: ~/cache
           key: cache-${{ runner.os }}

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -32,6 +32,6 @@ jobs:
         run: npm ci
 
       - name: Execute textlint
-        run: npx textlint -f checkstyle report.tex | reviewdog -f=checkstyle -name="textlint" -reporter="github-pr-review"
+        run: npx textlint -f checkstyle sample.tex | reviewdog -f=checkstyle -name="textlint" -reporter="github-pr-review"
         env:
           REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -14,7 +14,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
@@ -24,7 +24,7 @@ jobs:
           reviewdog_version: latest
 
       - name: Set up node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 20
 


### PR DESCRIPTION
## What

- Bump `actions/upload-artifact` from `v3` (deprecated) to **v7.0.1** in `.github/workflows/build.yml`.
- Bump `actions/cache` from `v3` to **v5.0.5** in `.github/workflows/build.yml` and `.github/workflows/dry-run.yml` (also drops the stray slash in `actions/cache/@v3`).
- Bump `actions/checkout` to **v6.0.2** and `actions/setup-node` to **v6.4.0** across all workflows.
- **Pin every `uses:` reference to its commit SHA** with a trailing `# vX.Y.Z` comment so Dependabot can still recognize and update the version.
- Point the reviewdog textlint step at `sample.tex` instead of the non-existent `report.tex` in `.github/workflows/reviewdog.yml`.

## Why

- The `build and upload` workflow on `main` has been failing on every push because GitHub hard-fails any run that uses `actions/upload-artifact@v3` (deprecation announced 2024-04-16). See run [25995669179](https://github.com/Okabe-Junya/latex-project-template/actions/runs/25995669179).
- `actions/cache@v3` is in the same deprecation track, and the rest of the workflows were still on floating `@v4` tags. Moving to the latest stable major versions keeps the CI on supported runtimes.
- **SHA pinning** removes a class of supply-chain attacks where a tag can be force-pushed to a malicious commit. This repo already pins `reviewdog/action-setup` for exactly that reason (see 9c6e4f4 "pin compromised reviewdog action to fixed SHA"); this PR extends the same hardening to every other action. The `# vX.Y.Z` comment is the convention Dependabot uses to track and bump SHA-pinned actions.
- The reviewdog workflow has been failing on every PR with `TextlintFileSearchError: Not found target files. Patterns: report.tex` because the repository only ships `sample.tex` — `report.tex` has never existed in git history. Pointing textlint at the actual sample file restores reviewdog as a useful PR gate.

## Test plan

- [ ] `build (dry run)` succeeds on this PR (exercises the updated `actions/cache@v5.0.5` and `actions/checkout@v6.0.2`).
- [ ] `reviewdog` succeeds on this PR (textlint now finds `sample.tex`; uses pinned `actions/setup-node@v6.4.0`).
- [ ] After merge, `build and upload` on `main` succeeds and uploads the `artifacts` artifact (exercises `actions/upload-artifact@v7.0.1`).