### PR TITLE
Add Dependabot config for actions, npm, and devcontainer Docker

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,39 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: chore(deps)
+    groups:
+      github-actions:
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: chore(deps)
+      prefix-development: chore(deps-dev)
+    groups:
+      textlint:
+        patterns:
+          - textlint
+          - "textlint-*"
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: docker
+    directory: /.devcontainer
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: chore(deps)


### PR DESCRIPTION
## What

Add `.github/dependabot.yml` to enable weekly Dependabot updates across three ecosystems:

| Ecosystem | Directory | What it tracks |
| --- | --- | --- |
| `github-actions` | `/` | The SHA-pinned `uses:` references in `.github/workflows/*.yml` |
| `npm` | `/` | `textlint` and the rule presets in `package.json` |
| `docker` | `/.devcontainer` | The `FROM paperist/texlive-ja` base image in the devcontainer |

Notable choices:
- **Minor/patch updates are grouped** (`groups:` for `github-actions` and `textlint`) so we get one rollup PR per ecosystem per week instead of one PR per package.
- **Commit-message prefixes** follow the repo's existing Conventional Commits style: `chore(deps)` for production / Actions, `chore(deps-dev)` for npm devDependencies. This matches the prior `9c6e4f4 chore(deps): bump textlint ...` commit.
- **`open-pull-requests-limit: 5`** per ecosystem caps backlog accumulation.

## Why

- The companion PR #11 SHA-pins every workflow action. Without Dependabot, those pinned SHAs would never get bumped and the repository would drift onto unpatched action versions. The `# vX.Y.Z` comments on each `uses:` line are exactly what Dependabot reads to keep SHA-pinned actions current.
- The repository ships `package.json` with eight textlint-related dev dependencies. The recent supply-chain incident that motivated `9c6e4f4` shows the cost of letting these drift; weekly automated bumps make patches easy to absorb.
- `.devcontainer/Dockerfile` pulls `paperist/texlive-ja:latest`, and CI also pulls the same image. Tracking the base image surfaces upstream rebuilds (security patches, TeX Live updates) instead of relying on `:latest` resolution at runtime.
- This repository is a **template repository** that other people fork as a starting point for LaTeX projects. Shipping a sensible Dependabot config means downstream users inherit the same automated hygiene without extra setup.

## Test plan

- [ ] After merge, confirm the Dependabot tab on GitHub recognizes all three ecosystems (Settings → Code security → Dependabot, or `gh api repos/Okabe-Junya/latex-project-template/dependabot/alerts`).
- [ ] Confirm Dependabot opens an initial sweep of update PRs within ~24 hours and that commit messages start with `chore(deps)` / `chore(deps-dev)`.
- [ ] Confirm grouped PRs (one for grouped textlint, one for grouped github-actions minor/patch) appear instead of one PR per package.