### PR TITLE
chore(ci): set least-privilege permissions for build workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,9 @@ on:
       - main
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/dry-run.yml
+++ b/.github/workflows/dry-run.yml
@@ -6,6 +6,9 @@ on:
       - main
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## What

Add a top-level `permissions: contents: read` block to `.github/workflows/build.yml` and `.github/workflows/dry-run.yml`.

## Why

`reviewdog.yml` already declares explicit permissions at the job level, but `build.yml` and `dry-run.yml` were inheriting the repository default token, which can be more permissive than needed. Setting the minimum required scope (`contents: read` is enough for `checkout`, `cache`, and `upload-artifact`) follows the GitHub Actions Security Hardening guideline and makes the security posture uniform across all workflows.