### PR TITLE
Remove deprecated textlint-rule-spellcheck-tech-word dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "latex-project-template",
+  "name": "latex-project-template-chore-drop-deprecated-spellcheck-rule",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -11,8 +11,7 @@
         "textlint-rule-preset-ja-engineering-paper": "^1.0.4",
         "textlint-rule-preset-ja-spacing": "^3.0.2",
         "textlint-rule-preset-ja-technical-writing": "^12.0.2",
-        "textlint-rule-prh": "^6.1.0",
-        "textlint-rule-spellcheck-tech-word": "^5.0.0"
+        "textlint-rule-prh": "^6.1.0"
       }
     },
     "node_modules/@azu/format-text": {
@@ -4679,32 +4678,6 @@
       "dev": true,
       "license": "CC0-1.0"
     },
-    "node_modules/spellcheck-technical-word": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/spellcheck-technical-word/-/spellcheck-technical-word-2.0.0.tgz",
-      "integrity": "sha512-8hcSijidDE5oemF66L3ASQBFtFjVaiEw+YfrIksmIW6pppko83uV8eb7Pszyf0YOAT1Ew/7+O7CENWxRUXlGyQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "structured-source": "^3.0.2",
-        "technical-word-rules": "^1.4.2"
-      }
-    },
-    "node_modules/spellcheck-technical-word/node_modules/boundary": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/boundary/-/boundary-1.0.1.tgz",
-      "integrity": "sha512-AaLhxHwYVh55iOTJncV3DE5o7RakEUSSj64XXEWRTiIhlp7aDI8qR0vY/k8Uw0Z234VjZi/iG/WxfrvqYPUCww==",
-      "dev": true
-    },
-    "node_modules/spellcheck-technical-word/node_modules/structured-source": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/structured-source/-/structured-source-3.0.2.tgz",
-      "integrity": "sha512-Ap7JHfKgmH40SUjumqyKTHYHNZ8GvGQskP34ks0ElHCDEig+bYGpmXVksxPSrgcY9rkJqhVMzfeg5GIpZelfpQ==",
-      "dev": true,
-      "dependencies": {
-        "boundary": "^1.0.1"
-      }
-    },
     "node_modules/sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
@@ -4869,13 +4842,6 @@
       "engines": {
         "node": ">=10.0.0"
       }
-    },
-    "node_modules/technical-word-rules": {
-      "version": "1.9.5",
-      "resolved": "https://registry.npmjs.org/technical-word-rules/-/technical-word-rules-1.9.5.tgz",
-      "integrity": "sha512-2sqzeb3aE23GtIO9fL9sDbqdt4vnoks7nWZRUgqEvYkjEmmQjrnVfl3WTURBZFrpgAXBNk0AMhWCj+17mzYXhw==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/text-table": {
       "version": "0.2.0",
@@ -6137,57 +6103,6 @@
         "sentence-splitter": "^5.0.0",
         "textlint-rule-helper": "^2.3.1",
         "textlint-util-to-string": "^3.3.4"
-      }
-    },
-    "node_modules/textlint-rule-spellcheck-tech-word": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/textlint-rule-spellcheck-tech-word/-/textlint-rule-spellcheck-tech-word-5.0.0.tgz",
-      "integrity": "sha512-BvQiWP5PZzRQQZLpGaai9XzQuQKGmJoP1wIgU8AiIGViEvX+NPoUUK4HLsZd31m0tBpQOU/4+rpy130jUf3Z8A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "spellcheck-technical-word": "^2.0.0",
-        "textlint-rule-helper": "^1.1.2"
-      },
-      "peerDependencies": {
-        "textlint": ">= 5.6.0"
-      }
-    },
-    "node_modules/textlint-rule-spellcheck-tech-word/node_modules/textlint-rule-helper": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/textlint-rule-helper/-/textlint-rule-helper-1.2.0.tgz",
-      "integrity": "sha512-yJmVbmyuUPOndKsxOijpx/G7mwybXXf4M10U2up0BeIZSN+6drUl+aSKAoC+RUHY7bG4ogLwRcmWoNG1lSrRIQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "unist-util-visit": "^1.1.0"
-      }
-    },
-    "node_modules/textlint-rule-spellcheck-tech-word/node_modules/unist-util-is": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-3.0.0.tgz",
-      "integrity": "sha512-sVZZX3+kspVNmLWBPAB6r+7D9ZgAFPNWm66f7YNb420RlQSbn+n8rG8dGZSkrER7ZIXGQYNm5pqC3v3HopH24A==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/textlint-rule-spellcheck-tech-word/node_modules/unist-util-visit": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-1.4.1.tgz",
-      "integrity": "sha512-AvGNk7Bb//EmJZyhtRUnNMEpId/AZ5Ph/KUpTI09WHQuDZHKovQ1oEv3mfmKpWKtoMzyMC4GLBm1Zy5k12fjIw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "unist-util-visit-parents": "^2.0.0"
-      }
-    },
-    "node_modules/textlint-rule-spellcheck-tech-word/node_modules/unist-util-visit-parents": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-2.1.2.tgz",
-      "integrity": "sha512-DyN5vD4NE3aSeB+PXYNKxzGsfocxp6asDc2XXE3b0ekO2BaRUpBicbbUygfSvYfUz1IkmjFR1YF7dPklraMZ2g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "unist-util-is": "^3.0.0"
       }
     },
     "node_modules/textlint-rule-use-si-units": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "latex-project-template-chore-drop-deprecated-spellcheck-rule",
+  "name": "latex-project-template",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
     "textlint-rule-preset-ja-engineering-paper": "^1.0.4",
     "textlint-rule-preset-ja-spacing": "^3.0.2",
     "textlint-rule-preset-ja-technical-writing": "^12.0.2",
-    "textlint-rule-prh": "^6.1.0",
-    "textlint-rule-spellcheck-tech-word": "^5.0.0"
+    "textlint-rule-prh": "^6.1.0"
   }
 }


### PR DESCRIPTION
## What

- `package.json`: drop the `textlint-rule-spellcheck-tech-word` devDependency.
- `package-lock.json`: regenerated with `npm install`, pruning the rule and its four nested copies of `textlint-rule-helper`, `unist-util-is`, `unist-util-visit` and `unist-util-visit-parents`.

## Why

`textlint-rule-spellcheck-tech-word` is deprecated upstream and is not going to receive fixes.
It was also dead weight here: `.textlintrc` enables `preset-ja-spacing`, `preset-ja-technical-writing`, `preset-ja-engineering-paper` and `preset-jtf-style`, and never references `spellcheck-tech-word`, so the package was resolved on every `npm ci` but never loaded by textlint.
Removing it shrinks the install without changing lint behaviour.

## Note

No replacement rule is added. Enabling a new active rule would change lint output on `sample.tex` and turn a zero-risk dependency removal into a behaviour change; that belongs in its own PR if wanted.

`npx textlint -f checkstyle sample.tex` (the CI invocation in `.github/workflows/reviewdog.yml`) produces byte-identical output before and after the removal — an empty `<file>` element and exit code 0.
